### PR TITLE
Improve performance of `Jisx0402::Tree::Node#values`

### DIFF
--- a/lib/jisx0402/tree.rb
+++ b/lib/jisx0402/tree.rb
@@ -46,7 +46,7 @@ class Jisx0402::Tree
     end
 
     def values
-      [value, @data.values.map(&:values)].flatten.compact
+      [value, *@data.values.map(&:values)].compact
     end
   end
 end


### PR DESCRIPTION
Benchmark
====

before

```
$ time ruby -I lib lib/jisx0402.rb

total  3.04s
user   2.77s
system 0.14s
CPU    96%
cmd    ruby -I lib lib/jisx0402.rb
```

after

```
time ruby -I lib lib/jisx0402.rb

total  2.59s
user   2.44s
system 0.11s
CPU    98%
cmd    ruby -I lib lib/jisx0402.rb
```

Profier output (stackprof)
===

```
==================================
  Mode: cpu(1000)
  Samples: 1451 (1.49% miss rate)
  GC: 403 (27.77%)
==================================
     TOTAL    (pct)     SAMPLES    (pct)     FRAME
       953  (65.7%)         429  (29.6%)     #<Module:0x00007f8daa8e0140>.zipcode_to_jisx0402_table
       403  (27.8%)         403  (27.8%)     (garbage collection)
       300  (20.7%)         300  (20.7%)     Jisx0402::Tree::Node#values
       395  (27.2%)          95   (6.5%)     Jisx0402::Tree::Node#search
        49   (3.4%)          49   (3.4%)     Jisx0402::DistrictArray.wrap
        38   (2.6%)          38   (2.6%)     Gem::StubSpecification#data
        41   (2.8%)          34   (2.3%)     Jisx0402::Tree::Node#insert
        76   (5.2%)          32   (2.2%)     #<Module:0x00007f8daa8e0140>.data_trees_index
        27   (1.9%)          27   (1.9%)     Gem::BasicSpecification#have_file?
      1048  (72.2%)          13   (0.9%)     Kernel#require
         7   (0.5%)           7   (0.5%)     Jisx0402::Tree::Node#initialize
         3   (0.2%)           3   (0.2%)     Gem::Version#_segments
         2   (0.1%)           2   (0.1%)     #<Module:0x00007f8daa8c9a08>.load
         5   (0.3%)           2   (0.1%)     Gem::Version#canonical_segments
         4   (0.3%)           2   (0.1%)     #<Module:0x00007f8daa8e0140>.open_msgpack_data
         3   (0.2%)           2   (0.1%)     Gem::StubSpecification#initialize
         2   (0.1%)           2   (0.1%)     #<Module:0x00007f8daa87d5b8>.lockfile_contents
         2   (0.1%)           2   (0.1%)     Gem::BasicSpecification#internal_init
       522  (36.0%)           2   (0.1%)     #<Module:0x00007f8daa8e0140>.forward_match_by
         1   (0.1%)           1   (0.1%)     Jisx0402::Code#initialize
         1   (0.1%)           1   (0.1%)     rescue in <top (required)>
         1   (0.1%)           1   (0.1%)     Gem::StubSpecification#missing_extensions?
         1   (0.1%)           1   (0.1%)     Gem::Version#_version
         7   (0.5%)           1   (0.1%)     Gem::Specification._resort!
         1   (0.1%)           1   (0.1%)     Kernel#require
         1   (0.1%)           1   (0.1%)     <module:JSON>
         1   (0.1%)           0   (0.0%)     Gem::Specification#internal_init
         1   (0.1%)           0   (0.0%)     Gem::Specification#initialize
         1   (0.1%)           0   (0.0%)     Gem::Specification.load
         1   (0.1%)           0   (0.0%)     Gem::StubSpecification#to_spec
```

Micro Benchmark
===

```ruby
require 'benchmark'

a = 1
b = [1,2,3]

Benchmark.bm do |x|
  x.report{1000000.times{[a, b].flatten}}
  x.report{1000000.times{[a, *b]}}
end
```

```
       user     system      total        real
   2.137477   0.008137   2.145614 (  2.151249)
   0.704152   0.001958   0.706110 (  0.708069)
```