### PR TITLE
Prefetch the result of forward_match_by_code

### DIFF
--- a/lib/jisx0402.rb
+++ b/lib/jisx0402.rb
@@ -73,8 +73,9 @@ module Jisx0402
     def zipcode_to_jisx0402_table
       @@zipcode_to_jisx0402_table ||= begin
         jisx0402_to_zipcode_table.map.with_object({}) do |(jisx0402, zipcodes), hash|
+          elem = forward_match_by_code(jisx0402).first
           zipcodes.map do |zipcode|
-            hash[zipcode] = forward_match_by_code(jisx0402).first
+            hash[zipcode] = elem
           end
 
           hash


### PR DESCRIPTION
forward_match_by_code is called in the loop of zipcodes, but I believe
each result of calls is the same.  By reusing the result, load time
becomes much faster:

Before:
```
$ time /usr/bin/time -f %Mkb ruby -I lib lib/jisx0402.rb
36324kb

real	0m0.634s
user	0m0.618s
sys	0m0.016s
```

After:
```
$ time /usr/bin/time -f %Mkb ruby -I lib lib/jisx0402.rb
33452kb

real	0m0.162s
user	0m0.129s
sys	0m0.034s
```